### PR TITLE
"Rename" the tls repo to pki

### DIFF
--- a/components/repo.ts
+++ b/components/repo.ts
@@ -13,7 +13,8 @@ abstract class Repo extends ComponentResource {
 		if (opts?.urn) return; // Refreshing
 
 		const repo = new gh.Repository(name, {
-			allowAutoMerge: true,
+			// I think this isn't allowed for private repos
+			allowAutoMerge: false,
 			allowMergeCommit: false,
 			allowRebaseMerge: false,
 			allowSquashMerge: true,
@@ -65,6 +66,7 @@ export class PublicRepo extends Repo {
 				name,
 				description: args.description,
 				visibility: 'public',
+				allowAutoMerge: true,
 			},
 		}, opts);
 

--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,6 @@
 import * as gh from '@pulumi/github';
 import { CustomResourceOptions } from '@pulumi/pulumi';
+import { PrivateRepo } from './components';
 
 function repo(
 	name: string,
@@ -78,9 +79,9 @@ function mainRuleset(name: string, repo: gh.Repository): gh.RepositoryRuleset {
 	});
 }
 
-const tlsRepo = privateRepo('tls', 'My TLS infrastructure', {
-	protect: true,
-});
+const pki = new PrivateRepo('pki', {
+	description: 'My private key infrastructure',
+}, { protect: true });
 
 const iowaDems = privateRepo(
 	'iowa-dems-mailer',


### PR DESCRIPTION
The name `tls` clashes with the `pulumi/tls` provider