### PR TITLE
Updated host filtering logic

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -15,10 +15,12 @@ const hosts = new PublicRepo('hosts', {
 		file: 'hosts.txt',
 		repository: 'UnstoppableMango/hosts',
 	}).apply(file => {
-		return file.content.trim().split('\n').map(x => ({
-			context: `pulumi (${x})`,
-			integrationId: integrationIds.github,
-		}));
+		return file.content.trim().split('\n')
+			.filter(x => !['apollo', 'pik8s0a'].includes(x))
+			.map(x => ({
+				context: `pulumi (${x})`,
+				integrationId: integrationIds.github,
+			}));
 	}),
 });
 


### PR DESCRIPTION
Enhanced the processing of hosts in index.ts. Now, it trims and splits the content by newline as before, but also filters out specific entries ('apollo', 'pik8s0a') before mapping to context and integrationId.
