### PR TITLE
Updated renovate.json with custom manager

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,5 +2,18 @@
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
 	"extends": [
 		"config:recommended"
+	],
+	"customManagers": [
+		{
+			"customType": "regex",
+			"depNameTemplate": "pulumi/pulumi",
+			"datasourceTemplate": "github-releases",
+			"fileMatch": [
+				"\\.versions\\/pulumi"
+			],
+			"matchStrings": [
+				"(?<currentValue>\\d+\\.\\d+\\.\\d+)"
+			]
+		}
 	]
 }


### PR DESCRIPTION
The renovate.json file has been updated to include a custom manager. This new addition is configured to use regex for matching, specifically targeting pulumi versions. The datasource template has been set to fetch from GitHub releases.
