### PR TITLE
Updated renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,6 +4,9 @@
 		"config:recommended"
 	],
 	"automerge": true,
+	"schedule": [
+		"before 4am on the first day of the month"
+	],
 	"customManagers": [
 		{
 			"customType": "regex",


### PR DESCRIPTION
Added a schedule for automerge in the renovate configuration file. The new setting will trigger automerge before 4am on the first day of each month.
