### PR TITLE
Removes concurrency cancel-in-progress

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     concurrency:
       group: ${{ github.ref }}
-      cancel-in-progress: true
     env:
       # renovate: datasource=github-releases depName=dprint/dprint
       DPRINT_VERSION: 0.50.0


### PR DESCRIPTION
Removes `cancel-in-progress` from the concurrency group
configuration in the CI workflow. This change ensures that
previous runs are not canceled when a new run is triggered
for the same branch, which can be useful for debugging or
analyzing historical build results.
